### PR TITLE
Add remaining components to script parsing

### DIFF
--- a/src/edolab/__main__.py
+++ b/src/edolab/__main__.py
@@ -52,8 +52,21 @@ def run(experiment, cores, seeds, root):
 
     for seed in tqdm.tqdm(range(seeds)):
         params = get_experiment_parameters(experiment)
-        opt = edo.DataOptimiser(**params)
-        _ = opt.run(root=out / str(seed), processes=cores, random_state=seed)
+
+        optimiser = params.pop("optimiser")
+        fitness_kwargs = params.pop("fitness_kwargs")
+        stop_kwargs = params.pop("stop_kwargs")
+        dwindle_kwargs = params.pop("dwindle_kwargs")
+
+        opt = optimiser(**params)
+        _ = opt.run(
+            root=out / str(seed),
+            processes=cores,
+            random_state=seed,
+            fitness_kwargs=fitness_kwargs,
+            stop_kwargs=stop_kwargs,
+            dwindle_kwargs=dwindle_kwargs,
+        )
 
     click.echo("Experiment complete")
 

--- a/src/edolab/__main__.py
+++ b/src/edolab/__main__.py
@@ -5,7 +5,6 @@ import pathlib
 import tarfile
 
 import click
-import edo
 import pandas as pd
 import tqdm
 

--- a/src/edolab/run.py
+++ b/src/edolab/run.py
@@ -10,12 +10,17 @@ def get_default_optimiser_arguments():
     """ Get the default arguments from `edo.DataOptimiser`. """
 
     signature = inspect.signature(edo.DataOptimiser)
-
-    return {
+    defaults = {
         k: v.default
         for k, v in signature.parameters.items()
         if v.default is not inspect.Parameter.empty
     }
+
+    defaults["fitness_kwargs"] = None
+    defaults["stop_kwargs"] = None
+    defaults["dwindle_kwargs"] = None
+
+    return defaults
 
 
 def get_experiment_parameters(experiment):
@@ -27,15 +32,16 @@ def get_experiment_parameters(experiment):
 
     module = {k.lower(): v for k, v in vars(experiment).items()}
 
-    module_params = {
-        k: v
-        for k, v in module.items()
-        if k in inspect.getfullargspec(edo.DataOptimiser).args
-    }
+    all_params = set(inspect.getfullargspec(edo.DataOptimiser).args) | set(
+        inspect.getfullargspec(edo.DataOptimiser.run).args
+    )
 
-    distributions = module["distributions"]
-    families = [edo.Family(distribution) for distribution in distributions]
-    module_params["families"] = families
+    module_params = {k: v for k, v in module.items() if k in all_params}
+
+    module_params["families"] = [
+        edo.Family(dist) for dist in module["distributions"]
+    ]
+    module_params["optimiser"] = module.get("optimiser", edo.DataOptimiser)
 
     params = get_default_optimiser_arguments()
     params.update(module_params)

--- a/tests/experiment.py
+++ b/tests/experiment.py
@@ -1,10 +1,26 @@
 """ Placeholder parameters. """
 
+import edo
 import numpy as np
 from edo.distributions import Uniform
 
 
-def fitness(individual, size=3, seed=0):
+class CustomOptimiser(edo.DataOptimiser):
+    """ This is an optimiser with custom stopping and dwindling methods. """
+
+    def stop(self, tol):
+        """ Stop if the median fitness is less than `tol` away from zero. """
+
+        self.converged = abs(np.median(self.pop_fitness)) < tol
+
+    def dwindle(self, rate):
+        """ Cut the mutation probability in half every `rate` generations. """
+
+        if self.generation % rate == 0:
+            self.mutation_prob /= 2
+
+
+def fitness(individual, size, seed=0):
     """ Randomly sample `size` values from an individual and return the
     minimum. """
 
@@ -22,12 +38,18 @@ class NegativeUniform(Uniform):
     hard_limits = {"bounds": [-100, 0]}
 
 
-Uniform.param_limits["bounds"] = [0, 1]
-
 size = 5
 row_limits = [1, 5]
 col_limits = [1, 2]
 max_iter = 3
 best_prop = 0.5
 mutation_prob = 0.5
+
+Uniform.param_limits["bounds"] = [0, 1]
+
 distributions = [Uniform, NegativeUniform]
+optimiser = CustomOptimiser
+
+fitness_kwargs = {"size": 3}
+stop_kwargs = {"tol": 1e-3}
+dwindle_kwargs = {"rate": 10}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -11,7 +11,7 @@ from edolab.run import (
     get_experiment_parameters,
 )
 
-from .experiment import NegativeUniform, fitness
+from .experiment import CustomOptimiser, NegativeUniform, fitness
 
 
 def test_get_default_optimiser_parameters():
@@ -27,6 +27,9 @@ def test_get_default_optimiser_parameters():
         "mutation_prob": 0.01,
         "shrinkage": None,
         "maximise": False,
+        "fitness_kwargs": None,
+        "stop_kwargs": None,
+        "dwindle_kwargs": None,
     }
 
     assert defaults == expected
@@ -50,12 +53,30 @@ def test_get_experiment_parameters():
         "mutation_prob": 0.5,
         "shrinkage": None,
         "maximise": False,
+        "optimiser": CustomOptimiser,
+        "fitness_kwargs": {"size": 3},
+        "stop_kwargs": {"tol": 1e-3},
+        "dwindle_kwargs": {"rate": 10},
     }
 
     for key, val in params.items():
         if key == "fitness":
             assert val.__doc__ == fitness.__doc__
             assert inspect.signature(val) == inspect.signature(fitness)
+
+        elif key == "optimiser":
+            assert val.__doc__ == CustomOptimiser.__doc__
+            assert inspect.signature(val) == inspect.signature(CustomOptimiser)
+            assert val.run is CustomOptimiser.run
+
+            for method in ("stop", "dwindle"):
+                assert inspect.signature(
+                    vars(val)[method]
+                ) == inspect.signature(vars(CustomOptimiser)[method])
+                assert (
+                    vars(val)[method].__doc__
+                    == vars(CustomOptimiser)[method].__doc__
+                )
 
         elif key == "families":
             families = val


### PR DESCRIPTION
Until now, only a fitness function and parameters for the default `DataOptimiser` class could be defined in an experiment script. With this PR, custom optimiser classes and parameters for its `run()` method can be defined.

An example of such a script is given in `tests/experiment.py`.