### PR TITLE
Remove root argument from summarise

### DIFF
--- a/src/edolab/__main__.py
+++ b/src/edolab/__main__.py
@@ -20,6 +20,16 @@ from .summarise import (
 from .version import __version__
 
 
+def _get_root_from_experiment(experiment):
+    """ Get the root directory from an experiment. If there isn't one, set the
+    root to be adjacent to the experiment script. """
+
+    root = get_experiment_parameters(experiment).pop("root")
+    root = experiment.parent if root is None else root
+
+    return root
+
+
 @click.group(invoke_without_command=True)
 @click.option(
     "--version", is_flag=True, default=False, help="The current version."
@@ -45,14 +55,13 @@ def run(experiment, cores, seeds):
 
     click.echo(f"Running experiment: {name}")
 
-    root = get_experiment_parameters(experiment).pop("root")
-    root = experiment.parent if root is None else root
-    root = pathlib.Path(root) / name / "data"
-    root.mkdir(exist_ok=True, parents=True)
+    root = _get_root_from_experiment(experiment)
+    out = pathlib.Path(root) / name / "data"
+    out.mkdir(exist_ok=True, parents=True)
 
-    click.echo(f"Writing to: {root}")
+    click.echo(f"Writing to: {out}")
 
-    tasks = (run_single_trial(experiment, root, seed) for seed in range(seeds))
+    tasks = (run_single_trial(experiment, out, seed) for seed in range(seeds))
 
     with ProgressBar():
         if cores is None:
@@ -70,23 +79,21 @@ def run(experiment, cores, seeds):
     help="Tarball the data and delete original, or don't.",
 )
 @click.argument("experiment", type=click.Path(exists=True))
-@click.argument("root", default=".", type=click.Path(exists=True))
 @click.argument("quantiles", nargs=-1, type=float, required=False)
-def summarise(tarball, experiment, root, quantiles):
+def summarise(tarball, experiment, quantiles):
     """ Summarise the EDO data from an experiment.
 
-    Here, `experiment` should be of the form
-    `/path/to/experiment/directory/{name}.py` and the data that will be
-    summarised is located under `root/{name}`.
+    Here, `experiment` should be a path to an experiment script of the form
+    `/path/to/experiment/<experiment-name>.py`.
 
-    To specify quantiles (between 0 and 1), list them at the end. Defaults to
-    the minimum, median and maximum. """
+    To specify quantiles (between 0 and 1), list them at the end separated by
+    spaces. Defaults to the minimum, median and maximum. """
 
     if not quantiles:
         quantiles = (0, 0.5, 1)
 
     experiment = pathlib.Path(experiment)
-
+    root = _get_root_from_experiment(experiment)
     out = pathlib.Path(root) / experiment.stem
     data = out / "data"
     summary_path = out / "summary"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,16 +96,17 @@ def test_run_makes_fitnesses_as_expected(tmpdir):
 def test_summarise_writes_to_file(tmpdir):
     """ Test that the `summarise` command writes something to file. """
 
-    out = pathlib.Path(tmpdir)
-    os.system(f"cp -r {here / 'experiment'} {out}")
+    there = pathlib.Path(tmpdir)
+    os.system(f"cp -r {here / 'experiment'} {there}")
+    os.system(f"cp {here / 'experiment.py'} {there}")
 
     runner = CliRunner()
     result = runner.invoke(
-        main, ["summarise", f"{here / 'experiment.py'}", f"{out}"]
+        main, ["summarise", f"{there / 'experiment.py'}"]
     )
     assert result.exit_code == 0
 
-    out = out / "experiment"
+    out = there / "experiment"
     assert [p.name for p in out.iterdir()] == ["data", "summary"]
 
     summary = out / "summary"
@@ -124,15 +125,16 @@ def test_summarise_writes_to_file(tmpdir):
 def test_summarise_makes_summary_as_expected(tmpdir):
     """ Test that the summary output is as expected. """
 
-    out = pathlib.Path(tmpdir)
-    os.system(f"cp -r {here / 'experiment'} {out}")
+    there = pathlib.Path(tmpdir)
+    os.system(f"cp -r {here / 'experiment'} {there}")
+    os.system(f"cp {here / 'experiment.py'} {there}")
 
     runner = CliRunner()
     _ = runner.invoke(
-        main, ["summarise", f"{here / 'experiment.py'}", f"{out}"]
+        main, ["summarise", f"{there / 'experiment.py'}"]
     )
 
-    summary = pd.read_csv(out / "experiment" / "summary" / "main.csv")
+    summary = pd.read_csv(there / "experiment" / "summary" / "main.csv")
     expected = pd.read_csv(here / "experiment" / "summary" / "main.csv")
 
     assert all(summary.columns == expected.columns)
@@ -142,10 +144,14 @@ def test_summarise_makes_summary_as_expected(tmpdir):
 def test_summarise_can_make_tarball(tmpdir):
     """ Test that the `summarise` command can compress the data when asked. """
 
-    out = pathlib.Path(tmpdir)
-    os.system(f"cp -r {here / 'experiment'} {out}/")
+    there = pathlib.Path(tmpdir)
+    os.system(f"cp -r {here / 'experiment'} {there}")
+    os.system(f"cp {here / 'experiment.py'} {there}")
 
-    os.system(f"edolab summarise --tarball {here / 'experiment.py'} {tmpdir}")
+    runner = CliRunner()
+    _ = runner.invoke(
+        main, ["summarise", "--tarball", f"{there / 'experiment.py'}"]
+    )
 
-    out = out / "experiment"
+    out = there / "experiment"
     assert {p.name for p in out.iterdir()} == {"data.tar.gz", "summary"}


### PR DESCRIPTION
For uniformity with the `run` command, the `root` argument is removed. This encourages defining it in the experiment script, and failing that, ensures that an experiment script won't be used to summarise data from another experiment.